### PR TITLE
Add support for WSL's mirrored networking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 Simple LSP server that sits between Neovim instance on WSL and the Godot LSP server running on Windows.
 
 This server only purpose is to convert the Windows and WSL path back and forth, to have a seamless experience editing GDScript files on Neovim running inside WSL (while Godot is still running on Windows).
+
+# Setup with `neovim/nvim-lspconfig`
+
+If you're using neovim's official `nvim-lspconfig`, the following configuration is recommended:
+
+```lua
+local lspconfig = require("lspconfig")
+
+lspconfig.gdscript.setup({
+    cmd = { "godot-wsl-lsp", "--useMirroredNetworking" },
+})
+```
+
+If you're using WSL's 'mirrored' networking mode, use the `--useMirroredNetworking` flag when starting your LSP client.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,48 @@
 
 Simple LSP server that sits between Neovim instance on WSL and the Godot LSP server running on Windows.
 
-This server only purpose is to convert the Windows and WSL path back and forth, to have a seamless experience editing GDScript files on Neovim running inside WSL (while Godot is still running on Windows).
+This server's only purpose is to convert the Windows and WSL path back and forth, to have a seamless experience editing GDScript files on Neovim running inside WSL (while Godot is still running on Windows).
 
-# Setup with `neovim/nvim-lspconfig`
+You can find more information on the entire setup process in [this gist](https://gist.github.com/lucasecdb/2baf6d328a10d7fea9ec085d868923a0).
 
-If you're using neovim's official `nvim-lspconfig`, the following configuration is recommended:
+The updated configuration from the previous gist using this server would be:
+
+```lua
+-- after/ftplugin/gdscript.lua
+
+local cmd = { "godot-wsl-lsp" }
+local pipe = "/tmp/godot.pipe"
+
+vim.lsp.start({
+    name = "Godot",
+    cmd = cmd,
+    filetypes = { "gdscript" },
+    root_dir = vim.fs.dirname(vim.fs.find({ "project.godot", ".git" }, {
+        upward = true,
+        path = vim.fs.dirname(vim.api.nvim_buf_get_name(0))
+    })[1]),
+    on_attach = function(client, bufnr)
+        vim.api.nvim_command('echo serverstart("' .. pipe .. '")')
+    end
+})
+```
+
+# Setup using `neovim/nvim-lspconfig`
+
+If you're using neovim's official `nvim-lspconfig`, you can omit setting up the lsp server using the naked `vim.lsp` API and `ftplugin`. In this case, the following configuration is recommended:
 
 ```lua
 local lspconfig = require("lspconfig")
 
 lspconfig.gdscript.setup({
-    cmd = { "godot-wsl-lsp", "--useMirroredNetworking" },
+    cmd = { "godot-wsl-lsp" },
 })
 ```
 
-If you're using WSL's 'mirrored' networking mode, use the `--useMirroredNetworking` flag when starting your LSP client.
+# WSL mirrored networking mode
+
+If you're using WSL's 'mirrored' networking mode (supported since [WSL 2.0.0](https://github.com/microsoft/WSL/releases/tag/2.0.0), you can use the `--useMirroredNetworking` flag when starting your lsp server:
+
+```lua
+cmd = { "godot-wsl-lsp", "--useMirroredNetworking" }
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Simple LSP server that sits between Neovim instance on WSL and the Godot LSP ser
 
 This server's only purpose is to convert the Windows and WSL path back and forth, to have a seamless experience editing GDScript files on Neovim running inside WSL (while Godot is still running on Windows).
 
+# Setup
+
 You can find more information on the entire setup process in [this gist](https://gist.github.com/lucasecdb/2baf6d328a10d7fea9ec085d868923a0).
 
 The updated configuration from the previous gist using this server would be:
@@ -28,7 +30,7 @@ vim.lsp.start({
 })
 ```
 
-# Setup using `neovim/nvim-lspconfig`
+## Setup using `neovim/nvim-lspconfig`
 
 If you're using neovim's official `nvim-lspconfig`, you can omit setting up the lsp server using the naked `vim.lsp` API and `ftplugin`. In this case, the following configuration is recommended:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "godot-wsl-lsp",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-wsl-lsp",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "json-rpc-2.0": "^1.7.0",
         "ts-lsp-client": "^1.0.1"
       },
       "bin": {
-        "godot-wsl-lsp": "dist/server.js"
+        "godot-wsl-lsp": "bin/godot-wsl-lsp"
       },
       "devDependencies": {
         "@types/node": "^20.11.20",

--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -1,0 +1,8 @@
+// Note: Consider using for example yargs if adding more flags (especially
+//       ones that should contain values of type other than boolean).
+
+type CliFlag = "--useMirroredNetworking";
+
+export function gotCliFlag(flag: CliFlag): boolean {
+  return process.argv.slice(2).includes(flag);
+}

--- a/src/lsp-socket.ts
+++ b/src/lsp-socket.ts
@@ -2,9 +2,12 @@ import * as os from "node:os";
 import * as dns from "node:dns/promises";
 import { AnyARecord } from "node:dns";
 import * as net from "node:net";
+import { gotCliFlag } from "./cli-flags.js";
 
 export async function getWindowsHostAddress() {
-  const host = os.hostname() + ".local";
+  const useMirroredNetworking = gotCliFlag("--useMirroredNetworking");
+  const host = useMirroredNetworking ? "localhost" : os.hostname() + ".local";
+
   const address = (
     (await dns.resolveAny(host)).find(
       (entry) => entry.type === "A",


### PR DESCRIPTION
If you're using WSL's mirrored networking mode (and, therefore, you can access your WSL's localhost from Windows using the localhost address and vice versa), the LSP socket fails to open due to there not being a valid dns entry in the current query result.

This pr addresses this by adding checking for a `--useMirroredNetworking` flag (i.e. CLI arg) in `lsp-socket.ts`, and, if found, sets the host to localhost.

I've also updated the readme to include some information on how to set this up. You may want to update your original gist, as it's probably the most well pieced together information on how to setup Neovim with Godot. While doing that, consider using the mirrored networking mode and `nvim/lsp-config` as defaults, as I think both are easier to setup than their alternatives, and they're both available in stable versions. Up to you.

Alternatively, if you're not up to it, I can do it. Again, up to you.