### PR TITLE
Add experimental flag to use fast path parsing algorithm

### DIFF
--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -4,6 +4,7 @@ import { hideBin } from "yargs/helpers";
 interface CliOptions {
   useMirroredNetworking: boolean;
   host?: string;
+  experimentalFastPathConversion: boolean;
 }
 
 const argv = (await yargs(hideBin(process.argv))
@@ -15,6 +16,13 @@ const argv = (await yargs(hideBin(process.argv))
   .option("host", {
     type: "string",
     description: "Manually specify the host address",
+  })
+  .option("experimentalFastPathConversion", {
+    type: "boolean",
+    description:
+      "[EXPERIMENTAL] Uses heuristical algorithm to convert paths between Windows-to-Linux format, " +
+      "without invoking `wslpath` in order to increase response times.",
+    default: false,
   })
   .help().argv) satisfies CliOptions;
 

--- a/src/wsl-path.ts
+++ b/src/wsl-path.ts
@@ -1,5 +1,7 @@
+import * as path from "node:path";
 import { promisify } from "node:util";
 import * as cp from "node:child_process";
+import { getCliOption } from "./cli-flags";
 
 const WSLPATH_BIN = "wslpath";
 
@@ -11,10 +13,36 @@ async function wslpath(args: string[]) {
   return stdout.trim();
 }
 
-export function convertWindowsToWslPath(filePath: string) {
+export function convertWindowsToWslPath(filePath: string): Promise<string> {
+  if (getCliOption("experimentalFastPathConversion")) {
+    const parsedPath = path.win32.parse(filePath);
+
+    const drive = parsedPath.root.split(":")[0];
+
+    return Promise.resolve(
+      path.posix.join(
+        BASE_MNT,
+        drive,
+        path.posix.relative(parsedPath.root, parsedPath.dir),
+        parsedPath.base,
+      ),
+    );
+  }
+
   return wslpath([filePath]);
 }
 
-export function convertWslToWindowsPath(filePath: string) {
+const BASE_MNT = "/mnt";
+
+export function convertWslToWindowsPath(filePath: string): Promise<string> {
+  if (getCliOption("experimentalFastPathConversion")) {
+    const relativeToMnt = path.relative(BASE_MNT, filePath);
+
+    const [drive, ...file] = relativeToMnt.split(path.posix.sep);
+
+    return Promise.resolve(
+      `${drive}:${path.posix.sep}${file.join(path.posix.sep)}`,
+    );
+  }
   return wslpath(["-m", filePath]);
 }

--- a/src/wsl-path.ts
+++ b/src/wsl-path.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { promisify } from "node:util";
 import * as cp from "node:child_process";
-import { getCliOption } from "./cli-flags";
+import { getCliOption } from "./cli-flags.js";
 
 const WSLPATH_BIN = "wslpath";
 


### PR DESCRIPTION
Adds a new flag `--experimentalFastPathConversion` in order to speed up the message proxying between WSL and Godot on Windows.