### PR TITLE
decode percent-encoded path values within `transformPathsForLinux` (Godot v4.5 breaking change)

### DIFF
--- a/src/rpc-message-transformer.ts
+++ b/src/rpc-message-transformer.ts
@@ -44,10 +44,13 @@ async function transformPathsForLinux<T>(value: T) {
     return value;
   }
 
+  // Godot 4.5 may communicate file URIs with percent-encoded characters (i.e."C%3A" instead of "C:")
+  const decodedValue = decodeURIComponent(value);
+
   return (
     FILE_URI_IDENTIFIER +
     (await convertWindowsToWslPath(
-      value.slice((FILE_URI_IDENTIFIER + path.posix.sep).length),
+      decodedValue.slice((FILE_URI_IDENTIFIER + path.posix.sep).length),
     ))
   );
 }


### PR DESCRIPTION
After upgrading a project to v4.5, go-to-definition and other actions were not working as expected for me. For example, trying to send me to a malformed version of the windows path rather than the expected WSL mount path. Reverting back to v4.4 would resolve these issues.

Digging into the differences between the payloads sent from the server in 4.5 vs 4.4, it looks like Godot is consistently sending these paths as percent/URL-encoded. For example, i printed out some of the objects that were being parsed from the server in `transformRpcForLinux` and `transformRpcForWindows` to see that all of the paths communicated in these payloads are encoded. For example:

Godot v4.4:
```
{
  "id": 3,
  "jsonrpc": "2.0",
  "result": [
    {
      "range": {
        "end": {
          "character": 25,
          "line": 0
        },
        "start": {
          "character": 11,
          "line": 0
        }
      },
      "uri": "file:///C:/Users/ben/Projects/project-fishinggame/game/components/state_component.gd"
    }
  ]
}
```

Godot v4.5:
```
{
  "id": 3,
  "jsonrpc": "2.0",
  "result": [
    {
      "range": {
        "end": {
          "character": 25,
          "line": 0
        },
        "start": {
          "character": 11,
          "line": 0
        }
      },
      "uri": "file:///C%3A/Users/ben/Projects/project-fishinggame/game/components/state_component.gd"
    }
  ]
}
```

I'm unfortunately having a really hard time getting any visibility into what LSP changes were made in Godot with the 4.5 release, and am not at all familiar with the internals of the project enough to know if this is something that is intended by the Godot team or rather a bug upstream that should be addressed in the Godot project - Wish i had more insight to provide here, but would love to hear if anyone has any context on those LSP changes or concerns about blindly decoding paths here to handle this seemingly breaking change.